### PR TITLE
bilibili playlist下载时 LUX will skip files with same names

### DIFF
--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -297,7 +297,7 @@ func multiEpisodeDownload(url, html string, extractOption extractors.Options, pa
 			aid:      u.Aid,
 			bvid:     u.BVid,
 			cid:      u.Cid,
-			subtitle: u.Title,
+			subtitle: fmt.Sprintf("P%d %s", dataIndex+1, u.Title),
 		}
 		go func(index int, options bilibiliOptions, extractedData []*extractors.Data) {
 			defer wgp.Done()


### PR DESCRIPTION
fix:  #1314  针对bilibili 合集下载的时候如果文件名相同会被跳过的问题



效果如下：
![image](https://github.com/leehow1988/lux/assets/6386894/c66bea3d-edfc-4468-a5f2-8cc4d38fd627)
